### PR TITLE
Add customer ticket portal with magic link authentication

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,281 @@
+# ARCHITECTURE.md
+
+Internal architecture reference for the Texas Combat Sports platform.
+
+## Overview
+
+Texas Combat Sports is a Next.js 14 full-stack application deployed on Vercel. It sells event tickets and merchandise for combat sport events in Texas. The app handles the full lifecycle: event creation, ticket tier configuration, Stripe checkout, PDF ticket generation with QR codes, email delivery via Resend, and day-of-event ticket scanning. An admin dashboard provides CRUD management for all entities. The codebase is a monolith -- there are no separate backend or frontend packages. All server logic lives in Next.js API routes. MongoDB Atlas is the sole datastore.
+
+## Repo Map
+
+```
+app/                        Next.js App Router (pages + API routes)
+  api/
+    auth/                   Login, token refresh, logout
+    checkout/               Stripe session creation + retrieval
+    webhooks/stripe/        Stripe webhook handler (payment lifecycle)
+    events/                 Event CRUD
+    fighters/               Fighter CRUD
+    fights/                 Fight CRUD
+    ticket-tiers/           Ticket tier CRUD
+    flash-sales/            Flash sale CRUD + per-tier lookup
+    tickets/                Ticket download (PDF) + mark-as-used
+    dolls/                  Doll CRUD
+    merch/                  Merchandise CRUD
+    videos/                 Video/streaming CRUD
+    gallery/                Cloudinary image listing (events, random)
+    images/                 Cloudinary image search with pagination
+    contact/                Contact form (sends email via Resend)
+  admin/                    Admin pages (login, dashboard, ticket-scan)
+  checkout/                 Checkout success page
+  events/                   Public event listing and detail pages
+  fighters/                 Public fighter profiles
+  dolls/                    Combat dolls catalog
+  gallery/                  Photo gallery
+  streaming/                Live streaming page
+
+components/
+  ui/                       55+ Radix UI primitives (button, dialog, tabs, etc.)
+  adminDashboard/           Admin panel components
+  home/                     Homepage sections
+  events/                   Event display components
+  dolls/                    Doll catalog components
+  streaming/                Live stream and video components
+  header.tsx, footer.tsx    Site-wide navigation and footer
+
+lib/
+  models/                   Mongoose schemas (see Data Model section)
+  services/                 Business logic layer -- one static class per model
+  middleware/auth.ts        JWT extraction, verification, admin guard
+  dbConnect.ts              MongoDB connection with global cache for hot reloads
+  stripe.ts                 Client-side Stripe loader + currency helpers
+  feature-flags.ts          TICKET_SALES_ENABLED, FLASH_SALES_ENABLED
+  utils/
+    ticket-generator.ts     PDF ticket creation (pdf-lib + qrcode)
+    order-id-generator.ts   Order ID and ticket number generation (CryptoJS)
+  db-helper.ts              CLI tool for DB operations (seed, test-connection)
+
+contexts/
+  auth-context.tsx          Admin auth state (JWT in memory, refresh via cookie)
+  query-context.tsx         TanStack React Query provider
+  current-event-context.tsx Shared current event state
+
+hooks/
+  use-queries.ts            All TanStack Query hooks (~1000 lines)
+  use-ticket-purchase.ts    Feature-flagged ticket purchase redirect
+  use-toast.ts              Toast notifications
+  use-mobile.tsx            Mobile viewport detection
+
+types/
+  stripe.ts                 Stripe-related TypeScript interfaces
+```
+
+## Runtime Architecture
+
+### Request Flow
+
+```
+Browser
+  |
+  +--> Next.js page (React, client components)
+  |      |
+  |      +--> TanStack Query hook (hooks/use-queries.ts)
+  |             |
+  |             +--> fetch() to /api/* route
+  |                    |
+  |                    +--> (optional) auth middleware check
+  |                    +--> Service class method (lib/services/*.ts)
+  |                           |
+  |                           +--> dbConnect() (cached Mongoose connection)
+  |                           +--> Mongoose model operation
+  |                           +--> Response JSON
+```
+
+All API routes follow the same pattern:
+1. GET routes are public (no auth required)
+2. POST/PUT/DELETE routes call `authenticateToken()` and `requireAdmin()` from `lib/middleware/auth.ts`
+3. The route delegates to a service class, which calls `dbConnect()` before any DB operation
+4. Responses are JSON with appropriate HTTP status codes
+
+### Authentication Flow
+
+```
+POST /api/auth/login
+  --> Validate credentials (bcryptjs compare)
+  --> Issue access token (JWT, 15min expiry, in response body)
+  --> Issue refresh token (JWT, 7d expiry, httpOnly cookie)
+
+POST /api/auth/refresh
+  --> Read refresh token from cookie
+  --> Verify with JWT_REFRESH_SECRET
+  --> Issue new access token
+  --> Rotate refresh token
+
+Client-side:
+  --> auth-context.tsx stores access token in React state
+  --> Attaches Bearer token to API requests via Authorization header
+  --> Refresh logic runs on 401 responses
+```
+
+### Checkout and Ticket Flow
+
+```
+1. User selects tickets on event page
+2. POST /api/checkout
+     --> Validate ticket availability (TicketTierService)
+     --> Check for active flash sales (FlashSaleService)
+     --> Create Stripe checkout session with metadata
+     --> Return session URL
+3. User pays on Stripe-hosted checkout
+4. Stripe sends webhook to POST /api/webhooks/stripe
+     --> checkout.session.completed:
+         a. Deduplicate by stripeSessionId (unique index)
+         b. Create Transaction record with generated orderId
+         c. Deduct ticket availability from TicketTier
+         d. Generate PDF tickets with QR codes (ticket-generator.ts)
+         e. Email tickets via Resend (email.service.ts)
+         f. Create 4% service fee transfer (transfer.service.ts)
+     --> charge.refunded:
+         a. Update transaction status to "refunded"
+         b. Reverse service fee transfer
+         c. Restore ticket availability
+5. User lands on /checkout/success
+     --> Fetches transaction, displays summary
+     --> Download button re-generates tickets via /api/tickets/[orderId]/download
+```
+
+### QR Code Data
+
+Each ticket's QR code encodes:
+```json
+{
+  "ticketNumber": "TXCS-20241215-A1B2C3D4E5F6",
+  "transactionId": "<MongoDB ObjectId>",
+  "timestamp": "<ISO 8601>"
+}
+```
+
+Scanned at the event via `/admin/ticket-scan` using html5-qrcode. The scan calls `POST /api/tickets/use/[transactionId]/[ticketNumber]` to mark the ticket as used.
+
+## Data Model
+
+All models use Mongoose with `timestamps: true` unless noted.
+
+### Event
+- `slug` (unique), `title`, `subtitle`, `date`, `venue`, `address`, `city`, `capacity`
+- `posterImage`, `heroVideo` (URLs)
+- `fights` --> array of ObjectId refs to Fight
+- `ticketTiers` --> array of ObjectId refs to TicketTier
+- `mainEventFight` --> ObjectId ref to Fight
+- `isActive`, `isPastEvent` flags
+
+### TicketTier
+- `name`, `description`, `price` (cents), `stripePriceId`
+- `maxQuantity`, `availableQuantity`
+- `features` (string array), `sortOrder`, `isActive`
+- Referenced by Event.ticketTiers
+
+### Transaction
+- `type`: "event_tickets" | "merchandise" | "mixed"
+- `orderId` (unique, format: `ORD-YYYYMMDD-HEX12`)
+- `event` --> ObjectId ref to Event
+- `ticketItems[]`: each has `ticketTier` ref, `tierName`, `quantity`, `price`, nested `tickets[]` with `ticketNumber` (unique sparse), `isUsed`, `usedAt`
+- `merchItems[]`: each has `merch` ref, `productName`, `selectedVariants[]`
+- `stripeSessionId` (unique), `stripePaymentIntentId`
+- `serviceAccountTransfer`: `{ transferId, amount, status, reversalId }`
+- `customerDetails`: email, name, phone, address
+- `summary`: totalItems, subtotal, taxes, fees, totalAmount (all cents), currency
+- `status`: "pending" | "confirmed" | "cancelled" | "refunded"
+- `shipping`: address, trackingNumber, shipping status (for merch)
+- Pre-save hook auto-generates ticket numbers
+
+### Fighter
+- `name`, `nickname`, `age`, `weight`, `height`, `reach`, `hometown`
+- `record` (string), `achievements[]`, `stats` (knockouts, submissions, decisions, winStreak)
+- `image`, `bio`
+
+### Fight
+- `fighter1`, `fighter2` --> ObjectId refs to Fighter
+- `event` --> ObjectId ref to Event
+- `weightClass`, `rounds`, `roundLength`
+- `status`, `result`, `method`
+
+### FlashSale
+- `title`, `description`, `startAt`, `endAt`
+- `targetTicketTypes[]` (ticket tier ID strings)
+- `stripePriceId` (sale price), `originalStripePriceId`
+- `isActive`
+- Overlap detection prevents two active sales on the same tier at the same time
+
+### Merch
+- `productId` (unique), `name`, `description`, `price`, `stripePriceId`
+- `images[]`, `category`, `variants[]` (name, options, required)
+- `inventory`: { total, available, reserved, lowStockThreshold }
+- Supports reserve/release/confirm inventory operations
+
+### Video
+- `title`, `description`, `videoUrl`, `thumbnailUrl`
+- `isLiveEvent`, `scheduledStartTime`, `liveStreamUrl`
+- `associatedEvent` --> ObjectId ref to Event
+- `viewCount`, `isPublic`
+- Indexes on isLiveEvent, associatedEvent, scheduledStartTime
+
+### Doll
+- `name`, `description`, `image`, `price`, `quantity`
+
+### User (admin only)
+- `username` (unique), `email` (unique), `password` (bcrypt hashed)
+- `role` (default "admin"), `isActive`, `lastLogin`
+- `refreshToken` (stored for session management)
+- Pre-save hook hashes password on change
+
+## Integration Architecture
+
+### Stripe
+- **Client library**: `@stripe/stripe-js` for frontend redirect, `stripe` (Node) for server operations
+- **Checkout**: Stripe-hosted checkout page with `allow_promotion_codes: true`
+- **Webhooks**: `POST /api/webhooks/stripe` with signature verification via `STRIPE_WEBHOOK_SECRET`
+- **Transfers**: 4% service fee to `SERVICE_ACCOUNT_ID` using `source_transaction` linking
+- **Refunds**: Handled via `charge.refunded` webhook, reverses transfers and restores inventory
+- **Idempotency**: Database-level via unique `stripeSessionId` index on Transaction. No Stripe-level idempotency keys used.
+- **Flash sales**: Use separate Stripe Price IDs. Active sale price replaces regular price at checkout time.
+
+### Resend (Email)
+- Sends ticket confirmation emails with PDF attachments after successful payment
+- Sends contact form submissions to category-specific inboxes (general, fight, venue, sponsor)
+- From address: `tickets@texascombatsportsllc.com`
+- No retry logic. Fallback: if attachment email fails, sends a simpler confirmation without PDFs.
+
+### Cloudinary
+- Used for event photo galleries. No SDK installed. Uses REST API directly with Basic auth.
+- Three API routes query Cloudinary: `/api/gallery/events`, `/api/gallery/random-images`, `/api/images`
+- Image optimization via URL transforms (f_auto, q_auto, c_fill)
+- Responses cached with `Cache-Control` and `next: { revalidate: 1800 }` (30 minutes)
+
+### Vercel
+- Deployed via GitHub integration. No `vercel.json` present.
+- Uses `@vercel/analytics` for page view tracking.
+- `next.config.mjs` ignores ESLint and TypeScript build errors.
+- Image optimization disabled (`unoptimized: true`).
+
+### YouTube
+- Embedded via iframe for live streaming (no API integration, just URL references)
+- Channel links in header and footer
+
+## Feature Flags
+
+Defined in `lib/feature-flags.ts` as a plain object (not env-var driven):
+
+| Flag | Purpose |
+|------|---------|
+| `TICKET_SALES_ENABLED` | When false, ticket purchase buttons show "Coming Soon" modal instead of checkout |
+| `FLASH_SALES_ENABLED` | When false, flash sale price overrides are skipped during checkout |
+
+## Assumptions and Unknowns
+
+- **No test framework** is configured (no Jest, Vitest, Playwright, etc.). The `test:*` npm scripts are standalone TypeScript scripts run via `tsx`, not test suites.
+- **No rate limiting** on any API route.
+- **No Next.js middleware** (`middleware.ts`) exists. Auth checks happen inside each API route handler.
+- **Promo deal logic** in the webhook has a special case: each "Promo Deal" purchase deducts from both the promo tier and 3x from the General Admission tier. The naming is hardcoded to look for "General Admission" tier by name.
+- **The `.env` file is committed to the repo** and contains test-mode Stripe keys. The `.env.local` file (gitignored) contains the active credentials.
+- It is unknown whether the organizer's Stripe account (`ORGANIZER_STRIPE_ACCOUNT_ID` in `.env.local`) is still used or if it has been fully replaced by `SERVICE_ACCOUNT_ID`. The codebase only references `SERVICE_ACCOUNT_ID`, but `.env.local` still defines `ORGANIZER_STRIPE_ACCOUNT_ID`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Texas Combat Sports — a Next.js 14 full-stack e-commerce platform for combat sport events. Handles event management, ticket sales (via Stripe), fighter profiles, merchandise, live streaming, and an admin dashboard with QR ticket scanning.
+
+## Commands
+
+```bash
+npm run dev          # Local dev server (Next.js)
+npm run build        # Production build
+npm run lint         # ESLint
+npm run db:seed      # Seed MongoDB database
+npm run db:test-connection  # Test MongoDB connection
+npm run test:tickets        # Test ticket PDF generation
+npm run test:order-id-qr    # Test order ID & QR code generation
+```
+
+## Tech Stack
+
+- **Framework:** Next.js 14.2 (App Router) with TypeScript
+- **Database:** MongoDB Atlas with Mongoose ODM
+- **Auth:** JWT (access token 15m + refresh token 7d in httpOnly cookie), bcryptjs, admin-only roles
+- **Payments:** Stripe (checkout sessions, webhooks, service fee transfers)
+- **UI:** Tailwind CSS, Radix UI primitives, Framer Motion
+- **Data Fetching:** TanStack React Query v5
+- **Forms:** React Hook Form + Zod validation
+- **Email:** Resend service with PDF ticket attachments (pdf-lib + qrcode)
+- **Images:** Cloudinary
+
+## Architecture
+
+### Directory Layout
+
+- `app/` — Next.js App Router pages and API routes
+- `app/api/` — REST API endpoints (auth, checkout, events, fighters, dolls, merch, videos, tickets, flash-sales, gallery, contact)
+- `app/admin/` — Protected admin pages (dashboard, ticket-scan, login)
+- `components/` — React components; `components/ui/` has 55+ Radix-based primitives
+- `lib/models/` — Mongoose schemas (Event, Fighter, Fight, Transaction, TicketTier, FlashSale, Merch, Video, Doll, User)
+- `lib/services/` — Business logic layer (one service per model)
+- `lib/middleware/auth.ts` — JWT verification middleware
+- `lib/dbConnect.ts` — MongoDB connection with global caching for hot reloads
+- `contexts/` — React Context providers (auth, query client, current event)
+- `hooks/use-queries.ts` — All TanStack Query hooks (~1000 lines); query keys follow `['resource', 'subresource', id]` pattern
+- `hooks/use-ticket-purchase.ts` — Ticket purchase flow hook
+- `types/` — TypeScript type definitions
+
+### Key Patterns
+
+- **API routes** return JSON with consistent error messages and HTTP status codes. Feature flags in `lib/feature-flags.ts` gate ticket sales and flash sales.
+- **Service layer** in `lib/services/` encapsulates all database operations and business logic; API routes delegate to services.
+- **Data fetching** uses TanStack Query hooks from `hooks/use-queries.ts` with query invalidation on mutations.
+- **Auth flow:** Admin login → JWT issued → access token in Authorization header (Bearer) → refresh via httpOnly cookie. Protected API routes use `lib/middleware/auth.ts`.
+- **Payment flow:** Create Stripe checkout session → redirect to Stripe → success page fetches transaction → email with PDF tickets containing QR codes.
+- **Path alias:** `@/*` maps to project root.
+
+### Environment Variables
+
+See `.env.example` for the full list with descriptions. Key vars:
+
+```
+MONGODB_URI, JWT_SECRET, JWT_REFRESH_SECRET,
+STRIPE_SECRET_KEY, NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY, STRIPE_WEBHOOK_SECRET, SERVICE_ACCOUNT_ID,
+RESEND_API_KEY, RESEND_GENERAL_EMAIL, RESEND_FIGHT_EMAIL, RESEND_VENUE_EMAIL, RESEND_SPONSOR_EMAIL,
+CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY, CLOUDINARY_API_SECRET,
+NEXT_PUBLIC_DOMAIN
+```
+
+## Build Notes
+
+- `next.config.mjs` ignores ESLint and TypeScript errors during build (legacy v0.dev compatibility).
+- Image optimization is disabled (`unoptimized: true`); images served from Cloudinary.
+- No test framework is configured. The `test:*` scripts are standalone verification scripts, not test suites.
+
+## Further Documentation
+
+- `ARCHITECTURE.md` -- data model, request flow, integration architecture
+- `RUNBOOK.md` -- local setup, deployment, common issues
+- `INTEGRATIONS.md` -- Stripe, Resend, Cloudinary, Vercel details with failure modes

--- a/INTEGRATIONS.md
+++ b/INTEGRATIONS.md
@@ -1,0 +1,251 @@
+# INTEGRATIONS.md
+
+Reference for all external service integrations in the Texas Combat Sports platform.
+
+---
+
+## Stripe
+
+| Field | Details |
+|-------|---------|
+| **Purpose** | Payment processing for event tickets and merchandise |
+| **SDK** | `stripe` (server, Node), `@stripe/stripe-js` (client, browser) |
+| **API version** | `2025-06-30.basil` (set in each server-side Stripe instantiation) |
+| **Configuration files** | `lib/stripe.ts` (client loader + currency helpers), `lib/services/transfer.service.ts`, `lib/services/flashSale.service.ts`, `app/api/checkout/route.ts`, `app/api/webhooks/stripe/route.ts` |
+| **Env vars** | `STRIPE_SECRET_KEY`, `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`, `STRIPE_WEBHOOK_SECRET`, `SERVICE_ACCOUNT_ID` |
+
+### Checkout Session
+
+Created in `app/api/checkout/route.ts` via `stripe.checkout.sessions.create()`:
+- Mode: `payment`
+- Payment methods: `card` only
+- Promotion codes: enabled (`allow_promotion_codes: true`)
+- Session expiry: 30 minutes
+- Billing address: required
+- Shipping address: US only
+- Phone collection: enabled
+- Success URL: `/checkout/success?session_id={CHECKOUT_SESSION_ID}`
+- Cancel URL: `/events/{eventId}?checkout=cancelled`
+
+Line items reference Stripe Price IDs stored in the TicketTier and FlashSale models. Prices are verified by calling `stripe.prices.retrieve()` before session creation.
+
+### Webhook Endpoint
+
+| Field | Details |
+|-------|---------|
+| **Path** | `POST /api/webhooks/stripe` |
+| **Signature verification** | Yes, via `stripe.webhooks.constructEvent()` |
+
+**Events handled:**
+
+| Event | Action |
+|-------|--------|
+| `checkout.session.completed` | Create Transaction record, deduct ticket availability, generate PDF tickets, email via Resend, create 4% service fee transfer |
+| `charge.refunded` | Mark transaction as refunded, reverse service fee transfer, restore ticket availability |
+| `checkout.session.expired` | Logged only (no ticket reservation to reverse) |
+| `payment_intent.succeeded` | Logged only |
+| `payment_intent.payment_failed` | Logged only |
+| `payment_intent.canceled` | Logged only |
+| `charge.dispute.created` | Logged only |
+| `charge.dispute.closed` | Logged only |
+| `charge.updated` | Logged only |
+
+### Stripe Connect (Transfers)
+
+Configured in `lib/services/transfer.service.ts`:
+- 4% of order total is transferred to `SERVICE_ACCOUNT_ID` (developer's Stripe account)
+- Uses `source_transaction` to link transfer to the original charge
+- Transfer metadata includes: transactionId, paymentIntentId, serviceFeePercentage, originalAmount
+- On refund: transfer is reversed via `stripe.transfers.createReversal()`, proportional to refund amount
+
+### Idempotency Strategy
+
+- **No Stripe-level idempotency keys** are used on API calls
+- **Database-level deduplication**: Transaction model has a unique index on `stripeSessionId`. The webhook checks for existing transactions before creating new ones.
+- Double-processing risk: If the unique index check and the insert race, MongoDB's unique constraint prevents duplicate records.
+
+### Flash Sale Pricing
+
+Configured in `lib/services/flashSale.service.ts`:
+- Each flash sale stores a `stripePriceId` (sale price) and `originalStripePriceId` (regular price)
+- At checkout, `getEffectiveStripePriceId()` returns the flash sale price if a sale is active for that tier
+- Flash sale overlap detection prevents two sales on the same tier at the same time
+
+### Failure Modes
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Webhook returns 400 | Invalid signature | Check `STRIPE_WEBHOOK_SECRET` matches the endpoint. For local dev, use the secret from `stripe listen`. |
+| Checkout session creation fails | Missing or invalid `STRIPE_SECRET_KEY` | Verify the key in `.env.local`. Check Stripe dashboard for key status. |
+| Transfers fail with "destination account not found" | `SERVICE_ACCOUNT_ID` is not set or invalid | Verify the account ID format (`acct_*`) and that the account exists. |
+| Flash sale price not applied | Feature flag `FLASH_SALES_ENABLED` is false, or sale is outside its time window | Check `lib/feature-flags.ts` and the flash sale's `startAt`/`endAt` in the database. |
+| Duplicate transactions | Webhook retried by Stripe | Should be caught by unique index on `stripeSessionId`. Check MongoDB logs if duplicates appear. |
+
+---
+
+## Resend (Email)
+
+| Field | Details |
+|-------|---------|
+| **Purpose** | Transactional email delivery (ticket confirmations, contact form) |
+| **SDK** | `resend` (Node) |
+| **Configuration files** | `lib/services/email.service.ts`, `app/api/contact/route.ts` |
+| **Env vars** | `RESEND_API_KEY`, `RESEND_GENERAL_EMAIL`, `RESEND_FIGHT_EMAIL`, `RESEND_VENUE_EMAIL`, `RESEND_SPONSOR_EMAIL` |
+
+### Email Types
+
+| Email | Trigger | From address | Attachments |
+|-------|---------|-------------|-------------|
+| Ticket confirmation | Stripe `checkout.session.completed` webhook | `tickets@texascombatsportsllc.com` | PDF ticket files (one per ticket) |
+| Simple confirmation (fallback) | Ticket confirmation email fails | `tickets@texascombatsportsllc.com` | None |
+| Contact form | `POST /api/contact` | `Texas Combat Sports <onboarding@resend.dev>` (or configured domain) | None |
+
+### Contact Form Routing
+
+The contact form sends to different inboxes based on the `reason` field:
+- General inquiry --> `RESEND_GENERAL_EMAIL`
+- Fight-related --> `RESEND_FIGHT_EMAIL`
+- Venue-related --> `RESEND_VENUE_EMAIL`
+- Sponsorship --> `RESEND_SPONSOR_EMAIL`
+
+### Templates
+
+All email templates are inline HTML strings in `EmailService` methods. There are no external template files. Templates use inline CSS for email client compatibility.
+
+### Failure Modes
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Ticket emails not sent | `RESEND_API_KEY` missing or invalid | Check env var. Check Resend dashboard for API key status. |
+| Emails rejected/bounced | From domain not verified in Resend | Verify `texascombatsportsllc.com` domain in Resend dashboard. |
+| Ticket email fails but payment succeeds | PDF generation error or Resend API error | Check Vercel function logs. The webhook sends a simpler fallback email without attachments. Users can still download tickets from the success page. |
+| Contact form emails not received | Recipient env vars not set | Check `RESEND_*_EMAIL` env vars are set to valid email addresses. |
+
+---
+
+## MongoDB Atlas
+
+| Field | Details |
+|-------|---------|
+| **Purpose** | Primary datastore for all application data |
+| **ODM** | Mongoose v8.16 |
+| **Configuration files** | `lib/dbConnect.ts`, `lib/models/*.ts` |
+| **Env vars** | `MONGODB_URI` |
+
+### Connection Pattern
+
+`lib/dbConnect.ts` uses a global variable to cache the Mongoose connection across hot reloads in development. `bufferCommands` is set to `false`. The connection is established lazily on first API call.
+
+Outside of Next.js (e.g., CLI scripts), the file attempts to load `dotenv` from `.env.local`.
+
+### Collections
+
+| Model | Collection | Key indexes |
+|-------|-----------|-------------|
+| Event | events | slug (unique) |
+| TicketTier | tickettiers | -- |
+| Transaction | transactions | orderId (unique), stripeSessionId (unique), ticketItems.tickets.ticketNumber (unique, sparse) |
+| Fighter | fighters | -- |
+| Fight | fights | -- |
+| FlashSale | flashsales | startAt+endAt (compound), targetTicketTypes, isActive, compound index on all four |
+| Merch | merches | productId (unique) |
+| Video | videos | isLiveEvent, associatedEvent, isPublic, scheduledStartTime, date, createdAt |
+| Doll | dolls | -- |
+| User | users | username (unique), email (unique) |
+
+### Failure Modes
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| "MONGODB_URI environment variable not defined" | Env var missing | Set `MONGODB_URI` in `.env.local` or Vercel env vars |
+| Connection timeout | IP not whitelisted in Atlas | Add your IP (or `0.0.0.0/0`) in Atlas Network Access |
+| Authentication failed | Wrong credentials in connection string | Check username/password in `MONGODB_URI` |
+| "buffering timed out" errors | Connection established but queries failing | Check Atlas cluster status. May indicate the cluster is paused (free tier) or under load. |
+
+---
+
+## Cloudinary
+
+| Field | Details |
+|-------|---------|
+| **Purpose** | Event photo storage and gallery delivery |
+| **SDK** | None (direct REST API calls with Basic auth) |
+| **Configuration files** | `app/api/images/route.ts`, `app/api/gallery/events/route.ts`, `app/api/gallery/random-images/route.ts` |
+| **Env vars** | `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET` |
+
+### API Usage
+
+- **Search API** (`POST /v1_1/{cloud}/resources/search`): Used to find images in `events/*` folders
+- **Folders API** (`GET /v1_1/{cloud}/folders/events`): Lists event photo folders
+- **URL transforms**: Images are optimized via URL path rewriting (e.g., `/upload/f_auto,q_auto:eco,w_250,h_170,c_fill/`)
+
+### Caching
+
+- API responses use `next: { revalidate: 1800 }` (30-minute ISR cache)
+- Response headers include `Cache-Control: public, max-age=1800, s-maxage=3600`
+
+### Failure Modes
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Gallery returns empty arrays | Cloudinary credentials wrong or no `events/` folder | Verify env vars. Check that images exist in Cloudinary under `events/` folder. |
+| 401 from Cloudinary API | API key or secret incorrect | Regenerate credentials in Cloudinary dashboard. |
+| Slow gallery load | Too many folders or images | The random-images endpoint limits to 15 images per folder. Check folder count. |
+
+---
+
+## Vercel
+
+| Field | Details |
+|-------|---------|
+| **Purpose** | Hosting and deployment |
+| **Configuration files** | `next.config.mjs` (no `vercel.json`) |
+| **Env vars** | `NEXT_PUBLIC_DOMAIN` (used for Stripe redirect URLs) |
+
+### Deployment
+
+- Automatic deploys via GitHub integration on push to main
+- Preview deployments on pull requests
+- No custom build command; uses Next.js defaults (`next build`)
+- Build ignores ESLint errors (`eslint.ignoreDuringBuilds: true`)
+- Build ignores TypeScript errors (`typescript.ignoreBuildErrors: true`)
+
+### Vercel Analytics
+
+`@vercel/analytics` package is installed and imported in `app/layout.tsx`. Provides automatic page view tracking in the Vercel dashboard.
+
+### Failure Modes
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Deploy succeeds but app crashes | Missing env vars on Vercel | Check all required env vars are set in Vercel project settings. |
+| Functions timeout | MongoDB connection slow or Stripe API slow | Check Atlas cluster region matches Vercel function region. Default function timeout is 10s. |
+| `NEXT_PUBLIC_DOMAIN` wrong in checkout redirects | Env var not set or set to localhost | Set to production URL (e.g., `https://texascombatsportsllc.com`) in Vercel env vars. Fallback is `http://localhost:3000`. |
+
+---
+
+## YouTube (Embedded)
+
+| Field | Details |
+|-------|---------|
+| **Purpose** | Live event streaming and fight recordings |
+| **SDK** | None (iframe embeds only) |
+| **Configuration files** | `components/streaming/live-stream-section.tsx`, `lib/models/Video.ts` |
+| **Env vars** | None |
+
+YouTube is used only via iframe embeds. Video URLs and live stream URLs are stored in the Video model and rendered in iframes. There is no YouTube Data API integration. Channel links appear in the header and footer.
+
+---
+
+## QR Code Libraries
+
+| Field | Details |
+|-------|---------|
+| **Purpose** | Ticket generation (server) and ticket scanning (client) |
+| **Libraries** | `qrcode` (server-side PNG generation), `html5-qrcode` (client-side camera scanning) |
+| **Configuration files** | `lib/utils/ticket-generator.ts` (generation), `app/admin/ticket-scan/page.tsx` (scanning) |
+| **Env vars** | None |
+
+- Server: `qrcode` generates PNG QR codes encoded as base64, embedded into PDF tickets via pdf-lib
+- Client: `html5-qrcode` provides camera-based QR scanning on the admin ticket scan page
+- QR data format: JSON with `ticketNumber`, `transactionId`, and `timestamp`

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,0 +1,199 @@
+# RUNBOOK.md
+
+Operational guide for developing, testing, and deploying the Texas Combat Sports platform.
+
+## Prerequisites
+
+| Requirement | Details |
+|-------------|---------|
+| Node.js | v18+ (no `.nvmrc` or `.node-version` file exists; Next.js 14.2 requires Node 18.17+) |
+| Package manager | npm (lockfile is `package-lock.json`) or pnpm (lockfile `pnpm-lock.yaml` also present) |
+| MongoDB Atlas | A cluster with a database. Free tier works for development. |
+| Stripe account | Test-mode keys for local development. Live keys for production. |
+| Resend account | API key for sending transactional emails. |
+| Cloudinary account | Cloud name, API key, and API secret for gallery features. |
+
+## Local Setup
+
+1. Clone the repo and install dependencies:
+
+```bash
+git clone <repo-url>
+cd texas-combat-sports
+npm install
+```
+
+2. Create `.env.local` at the repo root. Copy from `.env.example` and fill in real values. The app reads from `.env.local` first, falling back to `.env`.
+
+3. Test your database connection:
+
+```bash
+npm run db:test-connection
+```
+
+4. (Optional) Seed the database with sample data:
+
+```bash
+npm run db:seed
+```
+
+5. (Optional) Set up a complete event with ticket tiers:
+
+```bash
+npm run db:setup-complete-event
+```
+
+## Running the App
+
+### Development Server
+
+```bash
+npm run dev
+```
+
+Starts on `http://localhost:3000`. Hot reload is enabled. The MongoDB connection is cached globally to avoid connection leaks during hot reloads (see `lib/dbConnect.ts`).
+
+### Production Build
+
+```bash
+npm run build
+npm run start
+```
+
+Note: `next.config.mjs` ignores ESLint and TypeScript errors during build. This means the build will succeed even if there are type errors.
+
+## Linting
+
+```bash
+npm run lint
+```
+
+Runs Next.js built-in ESLint configuration. There is no Prettier config or formatting command.
+
+## Testing
+
+There is no test framework (no Jest, Vitest, or Playwright). The `test:*` scripts are standalone verification scripts:
+
+```bash
+npm run test:tickets         # Generates a sample ticket PDF to verify pdf-lib and qrcode work
+npm run test:order-id-qr     # Generates sample order IDs and QR codes to verify crypto-js works
+```
+
+These scripts use `tsx` to run TypeScript directly and load `.env.local` via dotenv.
+
+## Database Scripts
+
+All database scripts use `tsx` and load environment from `.env.local`:
+
+```bash
+npm run db:test-connection       # Verify MongoDB connectivity
+npm run db:seed                  # Insert sample fighters and event data
+npm run db:setup-complete-event  # Create a full event with ticket tiers
+npm run db:helper                # General-purpose DB access (interactive)
+```
+
+The `db-helper.ts` file also exports a `db` object that can be imported in other scripts for programmatic database access.
+
+## Stripe Webhook Testing
+
+For local development, use the Stripe CLI to forward webhooks:
+
+```bash
+stripe listen --forward-to localhost:3000/api/webhooks/stripe
+```
+
+This prints a webhook signing secret. Set it as `STRIPE_WEBHOOK_SECRET` in `.env.local`.
+
+The webhook handler is at `app/api/webhooks/stripe/route.ts` and processes these events:
+- `checkout.session.completed` -- creates transaction, deducts tickets, sends email, creates transfer
+- `charge.refunded` -- marks transaction refunded, reverses transfer, restores ticket availability
+- `checkout.session.expired`, `payment_intent.*`, `charge.dispute.*`, `charge.updated` -- logged only
+
+## Feature Flags
+
+Feature flags are hardcoded in `lib/feature-flags.ts` (not env-var driven). To toggle:
+
+1. Edit `lib/feature-flags.ts`
+2. Set `TICKET_SALES_ENABLED` or `FLASH_SALES_ENABLED` to `true` or `false`
+3. Redeploy (or restart dev server)
+
+When `TICKET_SALES_ENABLED` is false, the ticket purchase button shows a "Coming Soon" modal instead of navigating to checkout.
+
+## Admin Access
+
+The admin dashboard is at `/admin/dashboard`. To log in:
+
+1. Navigate to `/admin/login`
+2. Enter admin credentials
+3. After login, you can manage events, fighters, fights, ticket tiers, flash sales, merchandise, videos, dolls, and transactions
+
+To create an admin user programmatically:
+
+```bash
+npm run db:helper
+# Then use UserService.createUser() with role: 'admin'
+```
+
+The ticket scanner is at `/admin/ticket-scan`. It uses the device camera to scan QR codes and marks tickets as used.
+
+## Deployment (Vercel)
+
+### How It Deploys
+
+The repo is connected to Vercel via GitHub integration. Pushes to the main branch trigger automatic production deployments. Pull requests get preview deployments.
+
+There is no `vercel.json`. Vercel auto-detects Next.js and uses default settings.
+
+### Environment Variables
+
+All env vars from `.env.example` must be set in the Vercel project settings (Settings > Environment Variables). Make sure to use production/live values:
+- Stripe live keys (`sk_live_*`, `pk_live_*`)
+- Production `STRIPE_WEBHOOK_SECRET` (from the Vercel-hosted webhook endpoint in Stripe dashboard)
+- Production `MONGODB_URI` (ensure the Atlas cluster allows Vercel's IP range, or use `0.0.0.0/0`)
+- Production `NEXT_PUBLIC_DOMAIN` (e.g., `https://texascombatsportsllc.com`)
+
+### Validating a Deploy
+
+1. Visit the deployment URL
+2. Verify the homepage loads with event data
+3. Check that the events page loads and displays ticket tiers
+4. If ticket sales are enabled, verify the checkout flow reaches Stripe
+5. Check the admin login at `/admin/login`
+6. Check Vercel function logs for any startup errors (MongoDB connection failures are the most common)
+
+### Rollback
+
+Use the Vercel dashboard: Deployments > find the previous working deployment > Promote to Production.
+
+## Common Issues and Fixes
+
+### "MONGODB_URI environment variable not defined"
+
+The app requires `MONGODB_URI` in `.env.local` for local dev or in Vercel env vars for production. Make sure the variable is set and the connection string is valid.
+
+### MongoDB connection timeout
+
+- Check that your IP is whitelisted in MongoDB Atlas (Network Access)
+- For Vercel deploys, add `0.0.0.0/0` to allow all IPs (or use Vercel's IP list)
+- Check that the database user credentials in the connection string are correct
+
+### Stripe webhook signature verification failed
+
+- For local dev: make sure you are using the signing secret printed by `stripe listen`, not the one from the Stripe dashboard
+- For production: make sure `STRIPE_WEBHOOK_SECRET` matches the webhook endpoint configured in the Stripe dashboard
+
+### Tickets not being emailed after purchase
+
+- Check that `RESEND_API_KEY` is set
+- Check Vercel function logs for the webhook handler -- email errors are logged but do not fail the webhook
+- The from address (`tickets@texascombatsportsllc.com`) must be verified in Resend's domain settings
+
+### Gallery images not loading
+
+- Verify `CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, and `CLOUDINARY_API_SECRET` are set
+- Check that the Cloudinary account has an `events/` folder structure
+- Gallery API responses are cached for 30 minutes; changes may take time to appear
+
+### Build succeeds but types are broken
+
+`next.config.mjs` has `ignoreBuildErrors: true` for both ESLint and TypeScript. The build will not fail on type errors. Run `npm run lint` and `npx tsc --noEmit` manually to catch issues.

--- a/app/api/customer/auth/logout/route.ts
+++ b/app/api/customer/auth/logout/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  const response = NextResponse.json({ success: true });
+  response.cookies.set('customerToken', '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 0,
+    path: '/',
+  });
+  return response;
+}

--- a/app/api/customer/auth/request/route.ts
+++ b/app/api/customer/auth/request/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { CustomerAuthService } from '@/lib/services/customerAuth.service';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const email = typeof body.email === 'string' ? body.email.trim() : '';
+
+    if (!email || !EMAIL_REGEX.test(email)) {
+      return NextResponse.json({ error: 'A valid email address is required.' }, { status: 400 });
+    }
+
+    const result = await CustomerAuthService.requestMagicLink(email);
+
+    if (result.rateLimited) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please wait an hour before trying again.' },
+        { status: 429 }
+      );
+    }
+
+    // Generic message — never confirm or deny whether the email has orders
+    return NextResponse.json({
+      message: "If that email has orders with us, you'll receive a link shortly.",
+    });
+  } catch (error) {
+    console.error('Magic link request error:', error);
+    return NextResponse.json({ error: 'Something went wrong. Please try again.' }, { status: 500 });
+  }
+}

--- a/app/api/customer/auth/request/route.ts
+++ b/app/api/customer/auth/request/route.ts
@@ -21,10 +21,14 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Generic message — never confirm or deny whether the email has orders
-    return NextResponse.json({
-      message: "If that email has orders with us, you'll receive a link shortly.",
-    });
+    if (!result.hasOrders) {
+      return NextResponse.json(
+        { error: 'No orders found for that email address.' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ message: "Check your email for a link to access your tickets." });
   } catch (error) {
     console.error('Magic link request error:', error);
     return NextResponse.json({ error: 'Something went wrong. Please try again.' }, { status: 500 });

--- a/app/api/customer/auth/verify/route.ts
+++ b/app/api/customer/auth/verify/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { CustomerAuthService } from '@/lib/services/customerAuth.service';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  try {
+    const rawToken = req.nextUrl.searchParams.get('token');
+
+    if (!rawToken || rawToken.length !== 64) {
+      return NextResponse.redirect(new URL('/my-tickets?error=invalid-link', req.url));
+    }
+
+    const result = await CustomerAuthService.verifyMagicToken(rawToken);
+
+    if (!result) {
+      return NextResponse.redirect(new URL('/my-tickets?error=invalid-link', req.url));
+    }
+
+    const sessionJWT = CustomerAuthService.buildSessionJWT(result.email);
+
+    const response = NextResponse.redirect(new URL('/my-tickets/portal', req.url));
+
+    response.cookies.set('customerToken', sessionJWT, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax', // lax required — redirect arrives from email client (cross-site)
+      maxAge: 7 * 24 * 60 * 60,
+      path: '/',
+    });
+
+    return response;
+  } catch (error) {
+    console.error('Magic link verify error:', error);
+    return NextResponse.redirect(new URL('/my-tickets?error=invalid-link', req.url));
+  }
+}

--- a/app/api/customer/auth/verify/route.ts
+++ b/app/api/customer/auth/verify/route.ts
@@ -7,7 +7,7 @@ export async function GET(req: NextRequest) {
   try {
     const rawToken = req.nextUrl.searchParams.get('token');
 
-    if (!rawToken || rawToken.length !== 64) {
+    if (!rawToken || !/^[a-f0-9]{64}$/.test(rawToken)) {
       return NextResponse.redirect(new URL('/my-tickets?error=invalid-link', req.url));
     }
 

--- a/app/api/customer/orders/route.ts
+++ b/app/api/customer/orders/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateCustomer } from '@/lib/middleware/customerAuth';
+import dbConnect from '@/lib/dbConnect';
+import { Transaction } from '@/lib/models';
+
+const SENSITIVE_FIELDS = {
+  'customerDetails.address': 0,
+  stripeSessionId: 0,
+  stripePaymentIntentId: 0,
+  serviceAccountTransfer: 0,
+};
+
+export async function GET(req: NextRequest) {
+  const customer = authenticateCustomer(req);
+  if (!customer) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  try {
+    await dbConnect();
+
+    const transactions = await Transaction.find(
+      { 'customerDetails.email': customer.email },
+      SENSITIVE_FIELDS
+    )
+      .populate('event', 'title date venue')
+      .sort({ purchaseDate: -1 })
+      .lean();
+
+    const now = new Date();
+
+    const upcoming = transactions.filter((t: any) => {
+      const eventDate = t.event?.date ? new Date(t.event.date) : null;
+      return t.status === 'confirmed' && eventDate && eventDate >= now;
+    });
+
+    const past = transactions.filter((t: any) => {
+      const eventDate = t.event?.date ? new Date(t.event.date) : null;
+      return !upcoming.includes(t) && (
+        t.status !== 'confirmed' ||
+        !eventDate ||
+        eventDate < now
+      );
+    });
+
+    return NextResponse.json({ upcoming, past, email: customer.email });
+  } catch (error) {
+    console.error('Customer orders fetch error:', error);
+    return NextResponse.json({ error: 'Failed to fetch orders' }, { status: 500 });
+  }
+}

--- a/app/api/customer/tickets/resend/route.ts
+++ b/app/api/customer/tickets/resend/route.ts
@@ -28,7 +28,8 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Access denied' }, { status: 403 });
     }
 
-    const event = await EventService.getEventById(transaction.event?._id?.toString() || '');
+    const eventId = (transaction.event?._id ?? transaction.event)?.toString() ?? '';
+    const event = await EventService.getEventById(eventId);
     if (!event) {
       return NextResponse.json({ error: 'Event not found' }, { status: 404 });
     }

--- a/app/api/customer/tickets/resend/route.ts
+++ b/app/api/customer/tickets/resend/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateCustomer } from '@/lib/middleware/customerAuth';
+import { TransactionService } from '@/lib/services/transaction.service';
+import { EventService } from '@/lib/services/event.service';
+import { TicketGenerator } from '@/lib/utils/ticket-generator';
+import { EmailService } from '@/lib/services/email.service';
+
+export async function POST(req: NextRequest) {
+  const customer = authenticateCustomer(req);
+  if (!customer) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  try {
+    const { orderId } = await req.json();
+    if (!orderId || typeof orderId !== 'string') {
+      return NextResponse.json({ error: 'orderId is required' }, { status: 400 });
+    }
+
+    const transaction = await TransactionService.findTransactionByOrderId(orderId);
+
+    if (!transaction) {
+      return NextResponse.json({ error: 'Order not found' }, { status: 404 });
+    }
+
+    // Ownership check
+    if (transaction.customerDetails.email !== customer.email) {
+      return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+    }
+
+    const event = await EventService.getEventById(transaction.event?._id?.toString() || '');
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 });
+    }
+
+    const tickets = await TicketGenerator.generateMultipleTickets(transaction, event, {
+      includeQRCode: true,
+    });
+
+    const sent = await EmailService.sendTicketConfirmation({ transaction, event, tickets });
+
+    if (!sent) {
+      return NextResponse.json({ error: 'Failed to send email. Please try again.' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Resend tickets error:', error);
+    return NextResponse.json({ error: 'Something went wrong. Please try again.' }, { status: 500 });
+  }
+}

--- a/app/api/tickets/[orderId]/download/route.ts
+++ b/app/api/tickets/[orderId]/download/route.ts
@@ -2,8 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { TicketGenerator } from '@/lib/utils/ticket-generator';
 import { TransactionService } from '@/lib/services/transaction.service';
 import { EventService } from '@/lib/services/event.service';
-import { OrderIDGenerator } from '@/lib/utils/order-id-generator';
 import { PDFDocument } from 'pdf-lib';
+import { authenticateCustomer } from '@/lib/middleware/customerAuth';
 
 export async function GET(
   request: NextRequest,
@@ -16,21 +16,22 @@ export async function GET(
     //   return NextResponse.json({ error: 'Invalid order ID' }, { status: 400 });
     // }
 
-    // Find the transaction by ticket ID (using Stripe session ID or payment intent ID)
-    const transaction = await TransactionService.findTransactionByOrderId(
-      orderId
-    );
+    // Require customer session
+    const customer = authenticateCustomer(request);
+    if (!customer) {
+      return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+    }
 
-    console.log('Transaction:', transaction);
+    const transaction = await TransactionService.findTransactionByOrderId(orderId);
 
     if (!transaction) {
       return NextResponse.json({ error: 'Ticket not found' }, { status: 404 });
     }
 
-    // Verify the user owns this ticket (using username as email for now)
-    // if (transaction.customerDetails.email !== user.username) {
-    //   return NextResponse.json({ error: 'Access denied' }, { status: 403 });
-    // }
+    // Ownership check — customer can only download their own tickets
+    if (transaction.customerDetails.email !== customer.email) {
+      return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+    }
 
     // Get the associated event
     const event = await EventService.getEventById(

--- a/app/api/tickets/[orderId]/download/route.ts
+++ b/app/api/tickets/[orderId]/download/route.ts
@@ -34,9 +34,8 @@ export async function GET(
     }
 
     // Get the associated event
-    const event = await EventService.getEventById(
-      transaction.event?._id.toString() || ''
-    );
+    const eventId = (transaction.event?._id ?? transaction.event)?.toString() ?? '';
+    const event = await EventService.getEventById(eventId);
 
     if (!event) {
       return NextResponse.json({ error: 'Event not found' }, { status: 404 });

--- a/app/my-tickets/page.tsx
+++ b/app/my-tickets/page.tsx
@@ -48,17 +48,8 @@ function MyTicketsForm() {
   }
 
   return (
-    <div className="min-h-screen bg-black flex items-center justify-center px-4 py-16">
+    <div className="min-h-screen bg-black flex items-center justify-center px-4 pt-24 pb-16">
       <div className="w-full max-w-md">
-        {/* Logo / brand */}
-        <div className="text-center mb-8">
-          <Link href="/">
-            <span className="text-white font-black text-2xl tracking-tight uppercase">
-              Texas <span className="text-red-600">Combat</span> Sports
-            </span>
-          </Link>
-          <p className="text-gray-500 text-sm mt-2">Ticket Portal</p>
-        </div>
 
         <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
           <div className="bg-red-600 px-6 py-5">

--- a/app/my-tickets/page.tsx
+++ b/app/my-tickets/page.tsx
@@ -7,7 +7,7 @@ import Link from "next/link"
 function MyTicketsForm() {
   const searchParams = useSearchParams()
   const [email, setEmail] = useState("")
-  const [status, setStatus] = useState<"idle" | "loading" | "sent" | "error" | "ratelimit">("idle")
+  const [status, setStatus] = useState<"idle" | "loading" | "sent" | "error" | "ratelimit" | "noorders">("idle")
   const [errorMessage, setErrorMessage] = useState("")
 
   useEffect(() => {
@@ -31,6 +31,10 @@ function MyTicketsForm() {
 
       if (res.status === 429) {
         setStatus("ratelimit")
+        return
+      }
+      if (res.status === 404) {
+        setStatus("noorders")
         return
       }
       if (!res.ok) {
@@ -80,11 +84,13 @@ function MyTicketsForm() {
               </div>
             ) : (
               <form onSubmit={handleSubmit} className="space-y-4">
-                {(status === "error" || status === "ratelimit") && (
-                  <div className="bg-red-900/30 border border-red-800 rounded-lg px-4 py-3">
-                    <p className="text-red-400 text-sm">
+                {(status === "error" || status === "ratelimit" || status === "noorders") && (
+                  <div className={`border rounded-lg px-4 py-3 ${status === "noorders" ? "bg-yellow-900/20 border-yellow-800" : "bg-red-900/30 border-red-800"}`}>
+                    <p className={`text-sm ${status === "noorders" ? "text-yellow-400" : "text-red-400"}`}>
                       {status === "ratelimit"
                         ? "Too many requests. Please wait an hour before trying again."
+                        : status === "noorders"
+                        ? "We couldn't find any orders associated with that email. Double-check the email you used when purchasing."
                         : errorMessage}
                     </p>
                   </div>

--- a/app/my-tickets/page.tsx
+++ b/app/my-tickets/page.tsx
@@ -1,0 +1,156 @@
+"use client"
+
+import { useState, useEffect, Suspense } from "react"
+import { useSearchParams } from "next/navigation"
+import Link from "next/link"
+
+function MyTicketsForm() {
+  const searchParams = useSearchParams()
+  const [email, setEmail] = useState("")
+  const [status, setStatus] = useState<"idle" | "loading" | "sent" | "error" | "ratelimit">("idle")
+  const [errorMessage, setErrorMessage] = useState("")
+
+  useEffect(() => {
+    if (searchParams.get("error") === "invalid-link") {
+      setStatus("error")
+      setErrorMessage("That link has expired or already been used. Enter your email to get a new one.")
+    }
+  }, [searchParams])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setStatus("loading")
+    setErrorMessage("")
+
+    try {
+      const res = await fetch("/api/customer/auth/request", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      })
+
+      if (res.status === 429) {
+        setStatus("ratelimit")
+        return
+      }
+      if (!res.ok) {
+        const data = await res.json()
+        setStatus("error")
+        setErrorMessage(data.error || "Something went wrong. Please try again.")
+        return
+      }
+
+      setStatus("sent")
+    } catch {
+      setStatus("error")
+      setErrorMessage("Something went wrong. Please try again.")
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-black flex items-center justify-center px-4 py-16">
+      <div className="w-full max-w-md">
+        {/* Logo / brand */}
+        <div className="text-center mb-8">
+          <Link href="/">
+            <span className="text-white font-black text-2xl tracking-tight uppercase">
+              Texas <span className="text-red-600">Combat</span> Sports
+            </span>
+          </Link>
+          <p className="text-gray-500 text-sm mt-2">Ticket Portal</p>
+        </div>
+
+        <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+          <div className="bg-red-600 px-6 py-5">
+            <h1 className="text-white font-bold text-xl">Access Your Tickets</h1>
+            <p className="text-red-200 text-sm mt-1">
+              Enter the email you used when purchasing tickets
+            </p>
+          </div>
+
+          <div className="p-6">
+            {status === "sent" ? (
+              <div className="text-center py-4">
+                <div className="w-12 h-12 bg-green-500/20 rounded-full flex items-center justify-center mx-auto mb-4">
+                  <svg className="w-6 h-6 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                  </svg>
+                </div>
+                <h2 className="text-white font-semibold text-lg mb-2">Check your email</h2>
+                <p className="text-gray-400 text-sm leading-relaxed">
+                  If that email has orders with us, you&apos;ll receive a link to access your tickets. The link expires in 15 minutes.
+                </p>
+                <button
+                  onClick={() => { setStatus("idle"); setEmail("") }}
+                  className="mt-6 text-sm text-gray-500 hover:text-gray-300 transition-colors"
+                >
+                  Use a different email
+                </button>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                {(status === "error" || status === "ratelimit") && (
+                  <div className="bg-red-900/30 border border-red-800 rounded-lg px-4 py-3">
+                    <p className="text-red-400 text-sm">
+                      {status === "ratelimit"
+                        ? "Too many requests. Please wait an hour before trying again."
+                        : errorMessage}
+                    </p>
+                  </div>
+                )}
+
+                <div>
+                  <label htmlFor="email" className="block text-sm font-medium text-gray-300 mb-2">
+                    Email Address
+                  </label>
+                  <input
+                    id="email"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    placeholder="you@example.com"
+                    className="w-full bg-gray-800 border border-gray-700 text-white rounded-lg px-4 py-3 text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-red-600 focus:border-transparent"
+                  />
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={status === "loading"}
+                  className="w-full bg-red-600 hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed text-white font-semibold py-3 rounded-lg text-sm transition-colors flex items-center justify-center gap-2"
+                >
+                  {status === "loading" ? (
+                    <>
+                      <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+                      </svg>
+                      Sending link…
+                    </>
+                  ) : (
+                    "Send My Ticket Link"
+                  )}
+                </button>
+              </form>
+            )}
+          </div>
+        </div>
+
+        <p className="text-center text-gray-600 text-xs mt-6">
+          Need help?{" "}
+          <Link href="/contact" className="text-gray-500 hover:text-gray-300 transition-colors">
+            Contact us
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export default function MyTicketsPage() {
+  return (
+    <Suspense fallback={null}>
+      <MyTicketsForm />
+    </Suspense>
+  )
+}

--- a/app/my-tickets/portal/page.tsx
+++ b/app/my-tickets/portal/page.tsx
@@ -1,0 +1,262 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import { useRouter } from "next/navigation"
+import Link from "next/link"
+
+function fmtDate(d: string | Date) {
+  return new Date(d).toLocaleDateString("en-US", {
+    weekday: "long", month: "long", day: "numeric", year: "numeric",
+  })
+}
+
+function fmt(cents: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(cents / 100)
+}
+
+function QRCodeImage({ ticketNumber }: { ticketNumber: string }) {
+  const [src, setSrc] = useState<string>("")
+
+  useEffect(() => {
+    import("qrcode").then((QRCode) => {
+      QRCode.toDataURL(ticketNumber, { width: 160, margin: 1, color: { dark: "#000000", light: "#ffffff" } })
+        .then(setSrc)
+        .catch(console.error)
+    })
+  }, [ticketNumber])
+
+  if (!src) return <div className="w-[160px] h-[160px] bg-gray-800 rounded animate-pulse" />
+
+  return (
+    <div className="bg-white p-2 rounded-lg inline-block">
+      <img src={src} alt={`QR code for ticket ${ticketNumber}`} width={160} height={160} />
+    </div>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const map: Record<string, string> = {
+    confirmed: "bg-green-500/20 text-green-400 border-green-500/30",
+    pending:   "bg-yellow-500/20 text-yellow-400 border-yellow-500/30",
+    refunded:  "bg-red-500/20 text-red-400 border-red-500/30",
+    cancelled: "bg-gray-500/20 text-gray-400 border-gray-500/30",
+  }
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded-full border font-medium capitalize ${map[status] ?? map.cancelled}`}>
+      {status}
+    </span>
+  )
+}
+
+function OrderCard({ order, showQR }: { order: any; showQR: boolean }) {
+  const [expanded, setExpanded] = useState(showQR)
+
+  const tickets = (order.ticketItems ?? []).flatMap((item: any) =>
+    (item.tickets ?? []).map((t: any) => ({
+      ...t,
+      tierName: item.tierName,
+      quantity: item.quantity,
+    }))
+  )
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+      {/* Order header */}
+      <div className="px-5 py-4 flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h3 className="text-white font-semibold text-base truncate">
+              {order.event?.title ?? "Event"}
+            </h3>
+            <StatusBadge status={order.status} />
+          </div>
+          {order.event?.date && (
+            <p className="text-gray-500 text-sm mt-0.5">{fmtDate(order.event.date)}</p>
+          )}
+          {order.event?.venue && (
+            <p className="text-gray-600 text-xs mt-0.5">{order.event.venue}</p>
+          )}
+          <div className="flex items-center gap-3 mt-2 flex-wrap">
+            <span className="text-gray-400 text-xs font-mono">{order.orderId}</span>
+            <span className="text-gray-600 text-xs">·</span>
+            <span className="text-gray-400 text-xs">
+              {tickets.length} ticket{tickets.length !== 1 ? "s" : ""}
+            </span>
+            <span className="text-gray-600 text-xs">·</span>
+            <span className="text-gray-400 text-xs">{fmt(order.summary?.totalAmount ?? 0)}</span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <a
+            href={`/api/tickets/${order.orderId}/download`}
+            download
+            className="text-xs bg-gray-800 hover:bg-gray-700 text-gray-300 hover:text-white border border-gray-700 px-3 py-1.5 rounded-lg transition-colors whitespace-nowrap"
+          >
+            ↓ PDF
+          </a>
+          {showQR && tickets.length > 0 && (
+            <button
+              onClick={() => setExpanded((p) => !p)}
+              className="text-xs bg-red-600/20 hover:bg-red-600/30 text-red-400 border border-red-600/30 px-3 py-1.5 rounded-lg transition-colors whitespace-nowrap"
+            >
+              {expanded ? "Hide QR" : "Show QR"}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* QR codes */}
+      {expanded && showQR && tickets.length > 0 && (
+        <div className="border-t border-gray-800 px-5 py-5">
+          <p className="text-gray-500 text-xs mb-4 uppercase tracking-wider font-medium">Your Tickets</p>
+          <div className="flex flex-wrap gap-6">
+            {tickets.map((ticket: any) => (
+              <div key={ticket._id ?? ticket.ticketNumber} className="flex flex-col items-center gap-2">
+                <QRCodeImage ticketNumber={ticket.ticketNumber} />
+                <div className="text-center">
+                  <p className="text-white text-xs font-medium">{ticket.tierName}</p>
+                  <p className="text-gray-600 text-xs font-mono mt-0.5">{ticket.ticketNumber}</p>
+                  {ticket.isUsed && (
+                    <p className="text-red-400 text-xs mt-0.5">Used</p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function PortalPage() {
+  const router = useRouter()
+  const [data, setData] = useState<{ upcoming: any[]; past: any[]; email: string } | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [signingOut, setSigningOut] = useState(false)
+  const [pastExpanded, setPastExpanded] = useState(false)
+
+  const fetchOrders = useCallback(async () => {
+    try {
+      const res = await fetch("/api/customer/orders", { credentials: "include" })
+      if (res.status === 401) {
+        router.push("/my-tickets")
+        return
+      }
+      if (!res.ok) throw new Error("Failed to fetch")
+      setData(await res.json())
+    } catch {
+      router.push("/my-tickets")
+    } finally {
+      setLoading(false)
+    }
+  }, [router])
+
+  useEffect(() => { fetchOrders() }, [fetchOrders])
+
+  const handleSignOut = async () => {
+    setSigningOut(true)
+    await fetch("/api/customer/auth/logout", { method: "POST", credentials: "include" })
+    router.push("/my-tickets")
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-black flex items-center justify-center">
+        <div className="flex items-center gap-3 text-gray-500">
+          <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24" fill="none">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z" />
+          </svg>
+          Loading your tickets…
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-black">
+      {/* Header */}
+      <div className="border-b border-gray-900 bg-gray-950">
+        <div className="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between">
+          <div>
+            <Link href="/">
+              <span className="text-white font-black text-lg tracking-tight uppercase">
+                Texas <span className="text-red-600">Combat</span> Sports
+              </span>
+            </Link>
+            {data?.email && (
+              <p className="text-gray-600 text-xs mt-0.5">{data.email}</p>
+            )}
+          </div>
+          <button
+            onClick={handleSignOut}
+            disabled={signingOut}
+            className="text-sm text-gray-500 hover:text-gray-300 transition-colors disabled:opacity-50"
+          >
+            {signingOut ? "Signing out…" : "Sign out"}
+          </button>
+        </div>
+      </div>
+
+      <div className="max-w-3xl mx-auto px-4 py-8 space-y-10">
+
+        {/* Upcoming */}
+        <section>
+          <h2 className="text-white font-bold text-lg mb-4 flex items-center gap-2">
+            <span className="w-1.5 h-5 bg-red-600 rounded-full inline-block" />
+            Upcoming Events
+          </h2>
+          {data?.upcoming && data.upcoming.length > 0 ? (
+            <div className="space-y-4">
+              {data.upcoming.map((order: any) => (
+                <OrderCard key={order._id} order={order} showQR={true} />
+              ))}
+            </div>
+          ) : (
+            <div className="bg-gray-900 border border-gray-800 rounded-xl px-6 py-8 text-center">
+              <p className="text-gray-500 text-sm">No upcoming events.</p>
+              <Link
+                href="/events"
+                className="inline-block mt-3 text-sm text-red-500 hover:text-red-400 transition-colors"
+              >
+                Browse upcoming events →
+              </Link>
+            </div>
+          )}
+        </section>
+
+        {/* Past */}
+        {data?.past && data.past.length > 0 && (
+          <section>
+            <button
+              onClick={() => setPastExpanded((p) => !p)}
+              className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors w-full text-left"
+            >
+              <h2 className="font-bold text-lg flex items-center gap-2">
+                <span className="w-1.5 h-5 bg-gray-700 rounded-full inline-block" />
+                Past Orders
+                <span className="text-gray-600 text-sm font-normal">({data.past.length})</span>
+              </h2>
+              <svg
+                className={`ml-auto w-4 h-4 transition-transform ${pastExpanded ? "rotate-180" : ""}`}
+                fill="none" stroke="currentColor" viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+
+            {pastExpanded && (
+              <div className="space-y-4 mt-4">
+                {data.past.map((order: any) => (
+                  <OrderCard key={order._id} order={order} showQR={false} />
+                ))}
+              </div>
+            )}
+          </section>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/my-tickets/portal/page.tsx
+++ b/app/my-tickets/portal/page.tsx
@@ -16,14 +16,21 @@ function fmt(cents: number) {
 
 function QRCodeImage({ ticketNumber }: { ticketNumber: string }) {
   const [src, setSrc] = useState<string>("")
+  const [error, setError] = useState(false)
 
   useEffect(() => {
     import("qrcode").then((QRCode) => {
       QRCode.toDataURL(ticketNumber, { width: 160, margin: 1, color: { dark: "#000000", light: "#ffffff" } })
         .then(setSrc)
-        .catch(console.error)
-    })
+        .catch(() => setError(true))
+    }).catch(() => setError(true))
   }, [ticketNumber])
+
+  if (error) return (
+    <div className="w-[160px] h-[160px] bg-gray-800 rounded flex items-center justify-center">
+      <p className="text-gray-500 text-xs text-center px-2">QR unavailable — use ticket number below</p>
+    </div>
+  )
 
   if (!src) return <div className="w-[160px] h-[160px] bg-gray-800 rounded animate-pulse" />
 

--- a/app/my-tickets/portal/page.tsx
+++ b/app/my-tickets/portal/page.tsx
@@ -14,6 +14,19 @@ function fmt(cents: number) {
   return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(cents / 100)
 }
 
+function getCountdown(eventDate: string | Date): string {
+  const now = new Date()
+  const event = new Date(eventDate)
+  const diff = event.getTime() - now.getTime()
+  if (diff <= 0) return ""
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24))
+  const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60))
+  if (days > 1) return `${days} days away`
+  if (days === 1) return "Tomorrow"
+  if (hours > 0) return `${hours} hour${hours !== 1 ? "s" : ""} away`
+  return "Today!"
+}
+
 function QRCodeImage({ ticketNumber }: { ticketNumber: string }) {
   const [src, setSrc] = useState<string>("")
   const [error, setError] = useState(false)
@@ -57,17 +70,48 @@ function StatusBadge({ status }: { status: string }) {
 
 function OrderCard({ order, showQR }: { order: any; showQR: boolean }) {
   const [expanded, setExpanded] = useState(showQR)
+  const [resending, setResending] = useState(false)
+  const [resendStatus, setResendStatus] = useState<"idle" | "sent" | "error">("idle")
 
   const tickets = (order.ticketItems ?? []).flatMap((item: any) =>
     (item.tickets ?? []).map((t: any) => ({
       ...t,
       tierName: item.tierName,
-      quantity: item.quantity,
     }))
   )
 
+  const countdown = order.event?.date ? getCountdown(order.event.date) : ""
+
+  const handleResend = async () => {
+    setResending(true)
+    setResendStatus("idle")
+    try {
+      const res = await fetch("/api/customer/tickets/resend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ orderId: order.orderId }),
+      })
+      setResendStatus(res.ok ? "sent" : "error")
+    } catch {
+      setResendStatus("error")
+    } finally {
+      setResending(false)
+      // Reset after 4 seconds
+      setTimeout(() => setResendStatus("idle"), 4000)
+    }
+  }
+
   return (
     <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+      {/* Countdown banner for upcoming events */}
+      {showQR && countdown && (
+        <div className="bg-red-600/10 border-b border-red-600/20 px-5 py-2 flex items-center gap-2">
+          <span className="w-1.5 h-1.5 bg-red-500 rounded-full animate-pulse inline-block" />
+          <span className="text-red-400 text-xs font-semibold">{countdown}</span>
+        </div>
+      )}
+
       {/* Order header */}
       <div className="px-5 py-4 flex items-start justify-between gap-4">
         <div className="flex-1 min-w-0">
@@ -94,22 +138,36 @@ function OrderCard({ order, showQR }: { order: any; showQR: boolean }) {
           </div>
         </div>
 
-        <div className="flex items-center gap-2 flex-shrink-0">
-          <a
-            href={`/api/tickets/${order.orderId}/download`}
-            download
-            className="text-xs bg-gray-800 hover:bg-gray-700 text-gray-300 hover:text-white border border-gray-700 px-3 py-1.5 rounded-lg transition-colors whitespace-nowrap"
-          >
-            ↓ PDF
-          </a>
-          {showQR && tickets.length > 0 && (
-            <button
-              onClick={() => setExpanded((p) => !p)}
-              className="text-xs bg-red-600/20 hover:bg-red-600/30 text-red-400 border border-red-600/30 px-3 py-1.5 rounded-lg transition-colors whitespace-nowrap"
+        <div className="flex flex-col items-end gap-2 flex-shrink-0">
+          <div className="flex items-center gap-2">
+            <a
+              href={`/api/tickets/${order.orderId}/download`}
+              download
+              className="text-xs bg-gray-800 hover:bg-gray-700 text-gray-300 hover:text-white border border-gray-700 px-3 py-1.5 rounded-lg transition-colors whitespace-nowrap"
             >
-              {expanded ? "Hide QR" : "Show QR"}
-            </button>
-          )}
+              ↓ PDF
+            </a>
+            {showQR && tickets.length > 0 && (
+              <button
+                onClick={() => setExpanded((p) => !p)}
+                className="text-xs bg-red-600/20 hover:bg-red-600/30 text-red-400 border border-red-600/30 px-3 py-1.5 rounded-lg transition-colors whitespace-nowrap"
+              >
+                {expanded ? "Hide QR" : "Show QR"}
+              </button>
+            )}
+          </div>
+
+          {/* Resend tickets */}
+          <button
+            onClick={handleResend}
+            disabled={resending}
+            className="text-xs text-gray-600 hover:text-gray-400 transition-colors disabled:opacity-50 whitespace-nowrap"
+          >
+            {resending ? "Sending…" :
+             resendStatus === "sent" ? "✓ Sent to your email" :
+             resendStatus === "error" ? "Failed — try again" :
+             "Resend tickets to email"}
+          </button>
         </div>
       </div>
 
@@ -141,6 +199,7 @@ export default function PortalPage() {
   const router = useRouter()
   const [data, setData] = useState<{ upcoming: any[]; past: any[]; email: string } | null>(null)
   const [loading, setLoading] = useState(true)
+  const [sessionExpired, setSessionExpired] = useState(false)
   const [signingOut, setSigningOut] = useState(false)
   const [pastExpanded, setPastExpanded] = useState(false)
 
@@ -148,17 +207,18 @@ export default function PortalPage() {
     try {
       const res = await fetch("/api/customer/orders", { credentials: "include" })
       if (res.status === 401) {
-        router.push("/my-tickets")
+        setSessionExpired(true)
+        setLoading(false)
         return
       }
       if (!res.ok) throw new Error("Failed to fetch")
       setData(await res.json())
     } catch {
-      router.push("/my-tickets")
+      setSessionExpired(true)
     } finally {
       setLoading(false)
     }
-  }, [router])
+  }, [])
 
   useEffect(() => { fetchOrders() }, [fetchOrders])
 
@@ -182,19 +242,40 @@ export default function PortalPage() {
     )
   }
 
+  // Session expired — show message instead of silent redirect
+  if (sessionExpired) {
+    return (
+      <div className="min-h-screen bg-black flex items-center justify-center px-4">
+        <div className="w-full max-w-md text-center">
+          <div className="w-12 h-12 bg-yellow-500/20 rounded-full flex items-center justify-center mx-auto mb-4">
+            <svg className="w-6 h-6 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M12 3a9 9 0 100 18A9 9 0 0012 3z" />
+            </svg>
+          </div>
+          <h2 className="text-white font-bold text-lg mb-2">Your session has expired</h2>
+          <p className="text-gray-400 text-sm mb-6">
+            For your security, ticket access links expire after 24 hours. Enter your email to get a new link.
+          </p>
+          <Link
+            href="/my-tickets"
+            className="inline-block bg-red-600 hover:bg-red-700 text-white font-semibold px-6 py-3 rounded-lg text-sm transition-colors"
+          >
+            Get a new link
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="min-h-screen bg-black">
-      {/* Header */}
-      <div className="border-b border-gray-900 bg-gray-950">
-        <div className="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between">
+      <div className="max-w-3xl mx-auto px-4 pt-24 pb-8 space-y-10">
+        {/* Session info + sign out */}
+        <div className="flex items-center justify-between">
           <div>
-            <Link href="/">
-              <span className="text-white font-black text-lg tracking-tight uppercase">
-                Texas <span className="text-red-600">Combat</span> Sports
-              </span>
-            </Link>
+            <h1 className="text-white font-bold text-xl">My Tickets</h1>
             {data?.email && (
-              <p className="text-gray-600 text-xs mt-0.5">{data.email}</p>
+              <p className="text-gray-500 text-sm mt-0.5">{data.email}</p>
             )}
           </div>
           <button
@@ -205,9 +286,6 @@ export default function PortalPage() {
             {signingOut ? "Signing out…" : "Sign out"}
           </button>
         </div>
-      </div>
-
-      <div className="max-w-3xl mx-auto px-4 py-8 space-y-10">
 
         {/* Upcoming */}
         <section>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react"
 import Link from "next/link"
 import Image from "next/image"
-import { Menu, X, Instagram, Youtube, Facebook } from "lucide-react"
+import { Menu, X, Instagram, Youtube, Facebook, Ticket } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useCurrentEvent } from "@/contexts/current-event-context"
 import { useRouter, usePathname } from "next/navigation"
@@ -45,6 +45,7 @@ export default function Header() {
     { href: "/gallery", label: "Gallery" },
     { href: "/dolls", label: "Dolls" },
     { href: "/contact", label: "Contact" },
+    { href: "/my-tickets", label: "My Tickets" },
   ]
 
   return (
@@ -132,6 +133,15 @@ export default function Header() {
                 <TikTokIcon size={20} />
               </Link>
             </div>
+
+            {/* My Tickets */}
+            <Link
+              href="/my-tickets"
+              className={`text-gray-400 ${hoverColor} transition-colors`}
+              title="My Tickets"
+            >
+              <Ticket size={20} />
+            </Link>
 
             {/* Buy Tickets Button */}
             <Button

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -134,15 +134,6 @@ export default function Header() {
               </Link>
             </div>
 
-            {/* My Tickets */}
-            <Link
-              href="/my-tickets"
-              className={`text-gray-400 ${hoverColor} transition-colors`}
-              title="My Tickets"
-            >
-              <Ticket size={20} />
-            </Link>
-
             {/* Buy Tickets Button */}
             <Button
               size="sm"
@@ -170,6 +161,13 @@ export default function Header() {
             >
               Buy Tickets
             </Button>
+            <Link
+              href="/my-tickets"
+              className={`text-gray-400 ${hoverColor} transition-colors`}
+              title="My Tickets"
+            >
+              <Ticket size={22} />
+            </Link>
             <button className="text-white p-1" onClick={() => setIsMenuOpen(!isMenuOpen)}>
               {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
             </button>

--- a/components/home/hero-section.tsx
+++ b/components/home/hero-section.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button"
 import Image from "next/image"
+import Link from "next/link"
 import HeroParallax from "@/components/hero-parallax"
 import RevealAnimation from "@/components/reveal-animation"
 import { useCurrentEvent } from "@/contexts/current-event-context"
@@ -48,7 +49,7 @@ export default function HeroSection() {
               size="lg"
               className="bg-red-600 hover:bg-red-700 text-white px-8 py-4 text-lg font-bold transition-all duration-300 hover:scale-105 shadow-lg"
               onClick={() => handleTicketPurchase(currentEvent?.slug)}
-            > 
+            >
               Buy Tickets
             </Button>
             <Button
@@ -63,6 +64,15 @@ export default function HeroSection() {
             >
               See Fight Card
             </Button>
+            <Link href="/my-tickets">
+              <Button
+                size="lg"
+                variant="outline"
+                className="border-white/40 text-white hover:bg-white/10 hover:border-white px-8 py-4 text-lg font-bold transition-all duration-300 hover:scale-105 bg-transparent shadow-lg w-full sm:w-auto"
+              >
+                My Tickets
+              </Button>
+            </Link>
           </div>
         </RevealAnimation>
       </div>

--- a/lib/middleware/customerAuth.ts
+++ b/lib/middleware/customerAuth.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from 'next/server';
+import jwt from 'jsonwebtoken';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'your-super-secret-key';
+
+export interface CustomerJWTPayload {
+  email: string;
+  type: 'customer';
+  iat?: number;
+  exp?: number;
+}
+
+export function authenticateCustomer(request: NextRequest): CustomerJWTPayload | null {
+  try {
+    const token = request.cookies.get('customerToken')?.value;
+    if (!token) return null;
+
+    const decoded = jwt.verify(token, JWT_SECRET) as any;
+
+    // Must have type: 'customer' — prevents admin JWTs from being used here
+    if (decoded.type !== 'customer' || !decoded.email) return null;
+
+    return decoded as CustomerJWTPayload;
+  } catch {
+    return null;
+  }
+}

--- a/lib/middleware/customerAuth.ts
+++ b/lib/middleware/customerAuth.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import jwt from 'jsonwebtoken';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'your-super-secret-key';
+const CUSTOMER_JWT_SECRET = process.env.CUSTOMER_JWT_SECRET || 'your-customer-secret-key';
 
 export interface CustomerJWTPayload {
   email: string;
@@ -15,7 +15,7 @@ export function authenticateCustomer(request: NextRequest): CustomerJWTPayload |
     const token = request.cookies.get('customerToken')?.value;
     if (!token) return null;
 
-    const decoded = jwt.verify(token, JWT_SECRET) as any;
+    const decoded = jwt.verify(token, CUSTOMER_JWT_SECRET) as any;
 
     // Must have type: 'customer' — prevents admin JWTs from being used here
     if (decoded.type !== 'customer' || !decoded.email) return null;

--- a/lib/models/CustomerMagicToken.ts
+++ b/lib/models/CustomerMagicToken.ts
@@ -1,0 +1,49 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface ICustomerMagicToken extends Document {
+  email: string;
+  tokenHash: string;
+  isUsed: boolean;
+  expiresAt: Date;
+  createdAt: Date;
+}
+
+const CustomerMagicTokenSchema: Schema = new Schema(
+  {
+    email: {
+      type: String,
+      required: true,
+      lowercase: true,
+      trim: true,
+    },
+    tokenHash: {
+      type: String,
+      required: true,
+    },
+    isUsed: {
+      type: Boolean,
+      default: false,
+    },
+    expiresAt: {
+      type: Date,
+      required: true,
+    },
+  },
+  { timestamps: true }
+);
+
+// TTL index — MongoDB auto-deletes expired docs (background job, ~60s delay)
+// The service also checks expiresAt explicitly — do not rely on this alone
+CustomerMagicTokenSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+// For rate-limit count queries
+CustomerMagicTokenSchema.index({ email: 1, createdAt: 1 });
+
+// For token verification queries
+CustomerMagicTokenSchema.index({ tokenHash: 1, isUsed: 1, expiresAt: 1 });
+
+const CustomerMagicToken =
+  mongoose.models.CustomerMagicToken ||
+  mongoose.model<ICustomerMagicToken>('CustomerMagicToken', CustomerMagicTokenSchema);
+
+export default CustomerMagicToken;

--- a/lib/models/index.ts
+++ b/lib/models/index.ts
@@ -10,6 +10,7 @@ import Transaction from './Transaction';
 import User from './User';
 import FlashSale from './FlashSale';
 import Doll from './Doll';
+import CustomerMagicToken from './CustomerMagicToken';
 
 // Export all models for easy access
 export {
@@ -22,6 +23,7 @@ export {
   User,
   FlashSale,
   Doll,
+  CustomerMagicToken,
 };
 
 // Ensure all models are registered when this file is imported

--- a/lib/services/customerAuth.service.ts
+++ b/lib/services/customerAuth.service.ts
@@ -1,0 +1,85 @@
+import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
+import dbConnect from '@/lib/dbConnect';
+import { CustomerMagicToken, Transaction } from '@/lib/models';
+import { CustomerEmailService } from './customerEmail.service';
+
+const JWT_SECRET = process.env.JWT_SECRET || 'your-super-secret-key';
+const TOKEN_EXPIRY_MINUTES = 15;
+const RATE_LIMIT_MAX = 3;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour rolling window
+
+function hashToken(rawToken: string): string {
+  return crypto.createHash('sha256').update(rawToken).digest('hex');
+}
+
+export class CustomerAuthService {
+  static async requestMagicLink(email: string): Promise<{ success: boolean; rateLimited?: boolean }> {
+    await dbConnect();
+
+    const normalizedEmail = email.toLowerCase().trim();
+
+    // Rate limit check — rolling 1-hour window
+    const windowStart = new Date(Date.now() - RATE_LIMIT_WINDOW_MS);
+    const recentCount = await CustomerMagicToken.countDocuments({
+      email: normalizedEmail,
+      createdAt: { $gte: windowStart },
+    });
+
+    if (recentCount >= RATE_LIMIT_MAX) {
+      return { success: false, rateLimited: true };
+    }
+
+    // Check if email has any confirmed orders (don't reveal result to caller)
+    const hasOrders = await Transaction.exists({
+      'customerDetails.email': normalizedEmail,
+      status: 'confirmed',
+    });
+
+    // Generate and store token regardless — prevents timing-based enumeration
+    const rawToken = crypto.randomBytes(32).toString('hex');
+    const tokenHash = hashToken(rawToken);
+    const expiresAt = new Date(Date.now() + TOKEN_EXPIRY_MINUTES * 60 * 1000);
+
+    await CustomerMagicToken.create({ email: normalizedEmail, tokenHash, expiresAt });
+
+    // Only send the email if they have orders
+    if (hasOrders) {
+      const domain = process.env.NEXT_PUBLIC_DOMAIN || 'http://localhost:3000';
+      const magicLinkUrl = `${domain}/api/customer/auth/verify?token=${rawToken}`;
+      await CustomerEmailService.sendMagicLink(normalizedEmail, magicLinkUrl);
+    }
+
+    // Always return success — never reveal whether the email has orders
+    return { success: true };
+  }
+
+  static async verifyMagicToken(rawToken: string): Promise<{ email: string } | null> {
+    await dbConnect();
+
+    const tokenHash = hashToken(rawToken);
+
+    // Atomic find + mark used in one operation to prevent race conditions
+    const token = await CustomerMagicToken.findOneAndUpdate(
+      {
+        tokenHash,
+        isUsed: false,
+        expiresAt: { $gt: new Date() },
+      },
+      { isUsed: true },
+      { new: true }
+    );
+
+    if (!token) return null;
+
+    return { email: token.email };
+  }
+
+  static buildSessionJWT(email: string): string {
+    return jwt.sign(
+      { email, type: 'customer' },
+      JWT_SECRET,
+      { expiresIn: '7d' }
+    );
+  }
+}

--- a/lib/services/customerAuth.service.ts
+++ b/lib/services/customerAuth.service.ts
@@ -57,8 +57,7 @@ export class CustomerAuthService {
       await CustomerEmailService.sendMagicLink(normalizedEmail, magicLinkUrl);
     }
 
-    // Always return success — never reveal whether the email has orders
-    return { success: true };
+    return { success: true, hasOrders: !!hasOrders };
   }
 
   static async verifyMagicToken(rawToken: string): Promise<{ email: string } | null> {

--- a/lib/services/customerAuth.service.ts
+++ b/lib/services/customerAuth.service.ts
@@ -4,7 +4,7 @@ import dbConnect from '@/lib/dbConnect';
 import { CustomerMagicToken, Transaction } from '@/lib/models';
 import { CustomerEmailService } from './customerEmail.service';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'your-super-secret-key';
+const CUSTOMER_JWT_SECRET = process.env.CUSTOMER_JWT_SECRET || 'your-customer-secret-key';
 const TOKEN_EXPIRY_MINUTES = 15;
 const RATE_LIMIT_MAX = 3;
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour rolling window
@@ -35,6 +35,12 @@ export class CustomerAuthService {
       'customerDetails.email': normalizedEmail,
       status: 'confirmed',
     });
+
+    // Invalidate any previous unused tokens for this email
+    await CustomerMagicToken.updateMany(
+      { email: normalizedEmail, isUsed: false, expiresAt: { $gt: new Date() } },
+      { isUsed: true }
+    );
 
     // Generate and store token regardless — prevents timing-based enumeration
     const rawToken = crypto.randomBytes(32).toString('hex');
@@ -78,8 +84,8 @@ export class CustomerAuthService {
   static buildSessionJWT(email: string): string {
     return jwt.sign(
       { email, type: 'customer' },
-      JWT_SECRET,
-      { expiresIn: '7d' }
+      CUSTOMER_JWT_SECRET,
+      { expiresIn: '24h' }
     );
   }
 }

--- a/lib/services/customerAuth.service.ts
+++ b/lib/services/customerAuth.service.ts
@@ -51,7 +51,8 @@ export class CustomerAuthService {
 
     // Only send the email if they have orders
     if (hasOrders) {
-      const domain = process.env.NEXT_PUBLIC_DOMAIN || 'http://localhost:3000';
+      const domain = process.env.NEXT_PUBLIC_DOMAIN
+        || (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000');
       const magicLinkUrl = `${domain}/api/customer/auth/verify?token=${rawToken}`;
       await CustomerEmailService.sendMagicLink(normalizedEmail, magicLinkUrl);
     }

--- a/lib/services/customerEmail.service.ts
+++ b/lib/services/customerEmail.service.ts
@@ -1,0 +1,78 @@
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export class CustomerEmailService {
+  static async sendMagicLink(email: string, magicLinkUrl: string): Promise<boolean> {
+    try {
+      await resend.emails.send({
+        from: 'Texas Combat Sports <tickets@texascombatsportsllc.com>',
+        to: [email],
+        subject: 'Access Your Tickets — Texas Combat Sports',
+        html: `
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta charset="utf-8" />
+            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+          </head>
+          <body style="margin:0;padding:0;background:#0a0a0a;font-family:'Helvetica Neue',Arial,sans-serif;">
+            <table width="100%" cellpadding="0" cellspacing="0" style="background:#0a0a0a;padding:40px 16px;">
+              <tr>
+                <td align="center">
+                  <table width="100%" style="max-width:520px;background:#111;border-radius:12px;overflow:hidden;border:1px solid #222;">
+                    <!-- Header -->
+                    <tr>
+                      <td style="background:#e60000;padding:28px 32px;text-align:center;">
+                        <p style="margin:0;color:#fff;font-size:11px;font-weight:700;letter-spacing:3px;text-transform:uppercase;">Texas Combat Sports</p>
+                        <h1 style="margin:8px 0 0;color:#fff;font-size:22px;font-weight:800;">Your Ticket Access Link</h1>
+                      </td>
+                    </tr>
+                    <!-- Body -->
+                    <tr>
+                      <td style="padding:36px 32px;">
+                        <p style="margin:0 0 8px;color:#999;font-size:13px;">Requested for</p>
+                        <p style="margin:0 0 28px;color:#fff;font-size:15px;font-weight:600;">${email}</p>
+                        <p style="margin:0 0 28px;color:#aaa;font-size:14px;line-height:1.6;">
+                          Click the button below to view and download your tickets. This link expires in <strong style="color:#fff;">15 minutes</strong> and can only be used once.
+                        </p>
+                        <table cellpadding="0" cellspacing="0" width="100%">
+                          <tr>
+                            <td align="center">
+                              <a href="${magicLinkUrl}"
+                                style="display:inline-block;background:#e60000;color:#fff;font-size:15px;font-weight:700;text-decoration:none;padding:14px 36px;border-radius:8px;letter-spacing:0.3px;">
+                                View My Tickets
+                              </a>
+                            </td>
+                          </tr>
+                        </table>
+                        <p style="margin:28px 0 0;color:#555;font-size:12px;line-height:1.6;">
+                          If the button doesn't work, copy and paste this link into your browser:<br />
+                          <span style="color:#888;word-break:break-all;">${magicLinkUrl}</span>
+                        </p>
+                        <p style="margin:20px 0 0;color:#444;font-size:12px;">
+                          If you didn't request this, you can safely ignore this email.
+                        </p>
+                      </td>
+                    </tr>
+                    <!-- Footer -->
+                    <tr>
+                      <td style="padding:20px 32px;border-top:1px solid #222;text-align:center;">
+                        <p style="margin:0;color:#444;font-size:11px;">© ${new Date().getFullYear()} Texas Combat Sports. All rights reserved.</p>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </body>
+          </html>
+        `,
+      });
+      return true;
+    } catch (error) {
+      console.error('Failed to send magic link email:', error);
+      return false;
+    }
+  }
+}

--- a/lib/services/email.service.ts
+++ b/lib/services/email.service.ts
@@ -147,10 +147,17 @@ export class EmailService {
               </ul>
             </div>
 
+            <div style="text-align:center;margin:28px 0;">
+              <a href="${process.env.NEXT_PUBLIC_DOMAIN}/my-tickets" class="button" style="display:inline-block;padding:14px 28px;background:#e60000;color:white;text-decoration:none;border-radius:6px;font-weight:bold;font-size:15px;">
+                View My Tickets Online
+              </a>
+              <p style="margin-top:10px;font-size:12px;color:#888;">Access your tickets anytime at ${process.env.NEXT_PUBLIC_DOMAIN}/my-tickets</p>
+            </div>
+
             <p>If you have any questions, please contact us at <a href="mailto:support@texascombatsports.com">support@texascombatsports.com</a></p>
-            
+
             <p>We look forward to seeing you at the event!</p>
-            
+
             <p>Best regards,<br>The Texas Combat Sports Team</p>
           </div>
           
@@ -208,7 +215,9 @@ export class EmailService {
             <p><strong>Order ID:</strong> ${transaction.orderId}</p>
             
             <p>You will receive your tickets in a separate email shortly.</p>
-            
+
+            <p>You can also access your tickets anytime at <a href="${process.env.NEXT_PUBLIC_DOMAIN}/my-tickets" style="color:#e60000;font-weight:bold;">${process.env.NEXT_PUBLIC_DOMAIN}/my-tickets</a></p>
+
             <p>If you have any questions, please contact us at <a href="mailto:support@texascombatsports.com">support@texascombatsports.com</a></p>
           </div>
           


### PR DESCRIPTION
## Summary

- Passwordless magic link auth flow — customers enter their email at `/my-tickets`, receive a one-time link via Resend, and land in a secure session-cookie-protected portal
- Portal at `/my-tickets/portal` shows upcoming and past orders with QR codes, PDF download, and countdown banners ("X days away", "Tomorrow", "Today!")
- Resend tickets button on every order card — re-emails PDFs inline with status feedback
- Session expiry screen on 401 — friendly message with "Get a new link" instead of silent redirect
- Portal link added to all ticket confirmation emails
- "My Tickets" added to site header nav
- PDF download route (`/api/tickets/[orderId]/download`) now requires customer session + ownership check

## Security

- Tokens stored as SHA-256 hashes — raw token only travels in the email link, never persisted
- Atomic single-use enforcement via `findOneAndUpdate` with `isUsed: false` filter
- Rate limited to 3 requests/hour per email (rolling window)
- Customer JWT uses separate `CUSTOMER_JWT_SECRET` with `type: 'customer'` claim — cannot be confused with admin tokens
- Ownership checks on all ticket routes — customers can only access their own orders

## New env var required

```
CUSTOMER_JWT_SECRET=<random secret>
```

## Test plan

- [x] Request magic link with a known customer email — receive email, click link, land on portal
- [x] Click link a second time — redirected to `/my-tickets?error=invalid-link`
- [x] Wait for session to expire (or clear cookie) — 401 shows expiry screen
- [x] Resend tickets button sends email with PDF attachments
- [x] PDF download button serves combined PDF
- [x] Attempt to access another customer's order ID — returns 403
- [x] Request link 4+ times within an hour — 429 rate limit
- [x] "My Tickets" nav link visible in site header